### PR TITLE
Align page left and adjust responsive image

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,29 +6,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>StealthyMonkey's Blog</title>
   <style>
-    body {
-      font-family: sans-serif;
-      max-width: 900px;
-      margin: 40px auto;
-      line-height: 1.0;
-      padding: 0 40px;
-      background-color: #000;
-      color: #fff;
-    }
+      body {
+        font-family: sans-serif;
+        max-width: 900px;
+        margin: 40px 0;
+        line-height: 1.0;
+        padding: 0;
+        background-color: #000;
+        color: #fff;
+      }
     .container {
         width: 100%;
         padding: 0;
     }
     .content {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         align-items: flex-start;
         gap: 12px;
         padding: 20px;
     }
     .bio {
-        flex: 1;
-        min-width: 250px;
+        flex: 1 1 auto;
         text-align: left;
     }
     h1, h2 {
@@ -57,8 +56,7 @@
       text-decoration: underline;
     }
     .photo {
-        flex-shrink: 0;
-        max-width: 100%;
+        flex: 0 1 300px;
     }
     .photo img {
         width: 100%;
@@ -74,17 +72,8 @@
       padding: 0 20px;
     }
     @media (max-width: 600px) {
-      .content {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-
-      .photo img {
-        max-width: 100%;
-      }
-
-      li {
-        white-space: normal;
+      .photo {
+        flex-basis: 150px;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- align everything to the far left
- keep text from wrapping by default and allow the photo to shrink
- scale the photo down on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686438edbc84832eaf59e24669752abd