### PR TITLE
Remove images from subpages and center nav

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -21,7 +21,7 @@
     }
     .content {
         display: flex;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         align-items: flex-start;
         gap: 12px;
         padding: 20px;
@@ -49,8 +49,9 @@
           white-space: nowrap;
       }
       .nav {
-        margin-top: 20px;
-        text-align: left;
+        margin: 20px 0;
+        text-align: center;
+        width: 100%;
       }
       .nav a {
         margin-right: 15px;
@@ -62,15 +63,7 @@
     a:hover {
       text-decoration: underline;
     }
-    .photo {
-        flex: 0 1 300px;
-    }
-    .photo img {
-        width: 100%;
-        max-width: 200px;
-        height: auto;
-        display: block;
-    }
+
     footer {
       margin-top: 50px;
       font-size: 0.9em;
@@ -79,9 +72,6 @@
       padding: 0 20px;
     }
     @media (max-width: 600px) {
-      .photo {
-        flex-basis: 150px;
-      }
     }
   </style>
 </head>
@@ -96,9 +86,6 @@
               <a href="portfolio.html">Portfolio</a>
               <a href="books.html">Books</a>
             </nav>
-        </div>
-        <div class="photo">
-            <img src="https://cdn.costumewall.com/wp-content/uploads/2015/09/dexters-laboratory-costume.jpg" />
         </div>
     </div>
   <footer style="margin-top: 50px; font-size: 0.9em; color: gray;">

--- a/books.html
+++ b/books.html
@@ -21,7 +21,7 @@
     }
     .content {
         display: flex;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         align-items: flex-start;
         gap: 12px;
         padding: 20px;
@@ -49,8 +49,9 @@
           white-space: nowrap;
       }
       .nav {
-        margin-top: 20px;
-        text-align: left;
+        margin: 20px 0;
+        text-align: center;
+        width: 100%;
       }
       .nav a {
         margin-right: 15px;
@@ -62,15 +63,6 @@
     a:hover {
       text-decoration: underline;
     }
-    .photo {
-        flex: 0 1 300px;
-    }
-    .photo img {
-        width: 100%;
-        max-width: 200px;
-        height: auto;
-        display: block;
-    }
     footer {
       margin-top: 50px;
       font-size: 0.9em;
@@ -79,9 +71,6 @@
       padding: 0 20px;
     }
     @media (max-width: 600px) {
-      .photo {
-        flex-basis: 150px;
-      }
     }
   </style>
 </head>
@@ -96,9 +85,6 @@
               <a href="portfolio.html">Portfolio</a>
               <a href="books.html">Books</a>
             </nav>
-        </div>
-        <div class="photo">
-            <img src="https://cdn.costumewall.com/wp-content/uploads/2015/09/dexters-laboratory-costume.jpg" />
         </div>
     </div>
   <footer style="margin-top: 50px; font-size: 0.9em; color: gray;">

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     }
     .content {
         display: flex;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         align-items: flex-start;
         gap: 12px;
         padding: 20px;
@@ -49,8 +49,9 @@
           white-space: nowrap;
       }
       .nav {
-        margin-bottom: 20px;
-        text-align: left;
+        margin: 20px 0;
+        text-align: center;
+        width: 100%;
       }
       .nav a {
         margin-right: 15px;
@@ -86,12 +87,6 @@
   </style>
 </head>
 <body>
-        <nav class="nav">
-              <a href="index.html">Home</a>
-              <a href="blog.html">Blog</a>
-              <a href="portfolio.html">Portfolio</a>
-              <a href="books.html">Books</a>
-            </nav>  
         <div class="content">
           <div class="bio">
             <p>Hi! I'm StealthyMonkey, welcome to my website.</p>
@@ -101,11 +96,17 @@
                 <li>I am pursuing my masters in Data Science.</li>
                 <li>I like space, financial markets, technology.</li>
             </ul>
-        </div>
-        <div class="photo">
+          </div>
+          <nav class="nav">
+              <a href="index.html">Home</a>
+              <a href="blog.html">Blog</a>
+              <a href="portfolio.html">Portfolio</a>
+              <a href="books.html">Books</a>
+          </nav>
+          <div class="photo">
             <img src="https://cdn.costumewall.com/wp-content/uploads/2015/09/dexters-laboratory-costume.jpg" />
+          </div>
         </div>
-    </div>
   <footer style="margin-top: 50px; font-size: 0.9em; color: gray;">
     &copy; <span id="year"></span> StealthyMonkey. All rights reserved.
   </footer>

--- a/portfolio.html
+++ b/portfolio.html
@@ -21,7 +21,7 @@
     }
     .content {
         display: flex;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         align-items: flex-start;
         gap: 12px;
         padding: 20px;
@@ -49,8 +49,9 @@
           white-space: nowrap;
       }
       .nav {
-        margin-top: 20px;
-        text-align: left;
+        margin: 20px 0;
+        text-align: center;
+        width: 100%;
       }
       .nav a {
         margin-right: 15px;
@@ -62,15 +63,6 @@
     a:hover {
       text-decoration: underline;
     }
-    .photo {
-        flex: 0 1 300px;
-    }
-    .photo img {
-        width: 100%;
-        max-width: 200px;
-        height: auto;
-        display: block;
-    }
     footer {
       margin-top: 50px;
       font-size: 0.9em;
@@ -79,9 +71,6 @@
       padding: 0 20px;
     }
     @media (max-width: 600px) {
-      .photo {
-        flex-basis: 150px;
-      }
     }
   </style>
 </head>
@@ -96,9 +85,6 @@
               <a href="portfolio.html">Portfolio</a>
               <a href="books.html">Books</a>
             </nav>
-        </div>
-        <div class="photo">
-            <img src="https://cdn.costumewall.com/wp-content/uploads/2015/09/dexters-laboratory-costume.jpg" />
         </div>
     </div>
   <footer style="margin-top: 50px; font-size: 0.9em; color: gray;">


### PR DESCRIPTION
## Summary
- remove side image from Blog, Books, and Portfolio pages
- center navigation bar and keep it between bio text and image on the home page
- ensure centered nav on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864437dc090832e92aa2c34c131c551